### PR TITLE
Icon Match by Category (Feature)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,115 +1,190 @@
+<div align="center">
+  <img src="assets/images/myo_popup_transparent.png" alt="Yoto MYO Magic" width="600">
+</div>
+
 # Yoto MYO Magic
 
-> _Import playlists from ZIP files or folders to Yoto MYO cards with automatic icon matching._
+> _Transform how you create Yoto MYO cards with smart imports, automatic icon matching, and more delightful shortcuts._
 
-Transform how you create Yoto cards! Yoto MYO Magic is a Chrome Extension that lets you import entire playlists from ZIP files or folders directly to your Make Your Own (MYO) cards, complete with automatic icon matching for each track.
+Your MYO cards, ready to play as soon as you are. Drop in a ZIP file, point to a folder, or import your favorite podcasts — Yoto MYO Magic turns your raw audio into polished playlists with charming pixel art icons. It's like magic, without the manual fiddling.
 
-## ✨ Features
+## Perfect For
 
-Skip the tedious manual upload process! Import complete playlists with audio files, artwork, and icons in one click, then let the extension automatically match perfect icons to each track.
+- **Parents** creating custom story collections and educational content
+- **Teachers** building curriculum-aligned playlists
+- **Podcast Lovers** who want their favorite shows on Yoto
+- **Families** preserving audiobooks and music collections
+- **Anyone** tired of manual, repetitive playlist creation
 
-#### 📂 Bulk Import from ZIP or Folder
-- **ZIP File Import**: Upload a complete playlist from a single ZIP file
-- **Folder Import**: Select a folder containing your audio files
-- **Smart File Detection**: Automatically identifies audio files, cover art, and track icons
-- **Supported Formats**: MP3, M4A, WAV, OGG, FLAC, AAC, OPUS, WMA
-- **Automatic Transcoding**: Files are automatically converted to Yoto-compatible format
-
-![Demo](./demo/import-playlist-demo.gif)
-
-#### 🐙 Automatic Icon Management
-- **Smart Icon Matching**: AI-powered matching based on track titles
-- **Bulk Icon Import**: Include custom icons in your ZIP/folder (1.png, 2.png, etc.)
-- **Yoto Icon Library**: Access and search Yoto's entire icon collection
-- **Confidence Scoring**: See how certain the matches are
-- **Manual Override**: Easily change any suggestion
-
-![Demo](./demo/icon-match-demo.gif)
-
-#### 📤 Smart Upload Strategies
-- **Parallel Upload**: Fast upload for small playlists (< 20 tracks)
-- **Chunked Upload**: Reliable upload for large playlists (20+ tracks)
-- **Progress Tracking**: Real-time upload progress with percentage complete
-- **Error Recovery**: Automatic retry on failed uploads
-
-#### 🔒 Secure Authentication
-- **OAuth 2.0**: Secure login through Yoto's official authentication
-- **No Password Storage**: We never store your Yoto credentials
-- **Token Management**: Automatic token refresh for seamless experience
-
-## 🚀 Installation
+## Installation
 
 ### From Chrome Web Store
-1. Visit the [Chrome Web Store](https://chromewebstore.google.com/detail/iehnjhgdgfepcjlbfkpngibijmffcmpp?utm_source=item-share-cb)
+1. Search for [Yoto MYO Magic](https://chromewebstore.google.com/detail/iehnjhgdgfepcjlbfkpngibijmffcmpp?utm_source=item-share-cb) on the Chrome Web Store
 2. Click "Add to Chrome"
-3. Voila! The extension is installed
 
-## 📖 How to Use
+Buttons will auto-magically appear on the Yoto MYO playlist page!
 
-#### Import a Playlist
+## What's New
 
-1. **Prepare Your Files**:
-   - Create a folder with your audio files
-   - Optional: Add `cover.jpg/png` for album art
-   - Optional: Add numbered icons (`1.png`, `2.png`, etc.) for custom track icons
-   - Optional: Create a ZIP file of the folder
+### v1.3.0
 
-2. **Go to Yoto**:
-   - Navigate to [Yoto Make Your Own](https://us.yotoplay.com/make-your-own)
-   - Click "Vist Library / Make Playlist" → Log in
+- **🏷️ Category Icon Matching**: Apply themed icons to multiple tracks at once
 
-3. **Import Your Playlist**:
-   - Click the "Import Playlist" button (added by the extension)
-   - Choose either ZIP file or folder import
-   - Enter a playlist name
-   - Click "Start Import"
+### v1.2.0
+- **🎙️ Import Podcasts**: Search and import podcast episodes directly from ListenNotes
+- **⚡ Performance Boost**: Faster uploads with improved chunking strategy
+- **🔧 Better Error Recovery**: Automatic retry and extension context recovery
 
-4. **Watch the Magic**:
-   - Files are uploaded automatically
-   - Progress bar shows upload status
-   - Icons are matched to track titles
-   - Playlist is created on your MYO card
+## How to Use
 
-#### File Structure Example
+### 📂 Import Playlist from Files
 
+Transform your audio collection into a Yoto playlist in seconds:
+
+1. **Prepare Your Files** (any folder structure works!):
+   ```
+   my-playlist/
+   ├── cover.jpg          # Album artwork (optional)
+   ├── 01 - Track One.mp3
+   ├── 02 - Track Two.mp3
+   ├── 03 - Track Three.mp3
+   ├── 1.png             # Custom icon for track 1 (optional)
+   ├── 2.png             # Custom icon for track 2 (optional)
+   └── 3.png             # Custom icon for track 3 (optional)
+   ```
+
+2. **Navigate to Yoto**:
+   - Go to [Make Your Own](https://my.yotoplay.com/library/make-your-own)
+   - Click on your MYO card
+   - Click "Add a playlist"
+
+3. **Import Your Content**:
+   - Click the **"Import Playlist"** button (added by the extension)
+   - Choose ZIP file or folder
+   - Name your playlist
+   - You audio, icons, and cover art upload automatically!
+
+![Import Playlist Demo](./demo/import-playlist-demo.gif)
+
+### 🎙️ Import Podcasts
+
+Bring your favorite podcasts to Yoto:
+
+1. **Find Your Podcast**:
+   - Click **"Import Podcast"** on the playlist page
+   - Browse "Best Kids Podcasts" or search by name
+   - Select episodes you want
+
+2. **Automatic Import**:
+   - Episodes download automatically
+   - Metadata and thumbnails included
+
+![Import Podcast Demo](./demo/import-podcast-demo.gif)
+
+### 🎨 Automatic Icon Matching
+
+Let AI find the perfect icons for your tracks:
+
+#### Single Track Icons
+- Click the icon button next to any track
+- AI suggests matching icons based on the title
+- See confidence scores for each match
+- Search manually if needed
+
+#### Category-Based Matching
+- Select multiple tracks
+- Click **"Match by Category"**
+- Choose a theme (Animals, Nature, Music, etc.)
+- Apply themed icons to all selected tracks at once
+
+![Icon Match Demo](./demo/icon-match-demo.gif)
+
+## Features in Detail
+
+### Supported Formats
+
+- **Audio**: MP3, M4A, WAV, OGG, FLAC, AAC, OPUS, WMA
+- **Images**: JPG, PNG (for cover art and custom icons)
+- **Archives**: ZIP files for bundled content
+
+### Upload Strategies
+
+The extension intelligently chooses the best upload strategy:
+- **Parallel Upload** (< 20 tracks): Fast concurrent uploads
+- **Chunked Upload** (20+ tracks): Reliable sequential processing
+- **Adaptive Chunking**: Adjusts based on file sizes and network conditions
+
+## 🔒 Privacy & Security
+
+- **OAuth 2.0 Authentication**: Secure login through Yoto's official auth
+- **No Password Storage**: We never store your credentials
+- **Local Storage Only**: Settings saved in your browser
+- **No Server Storage**: Your content never touches our servers
+- **Analytics**: Anonymous usage tracking (no personal data)
+
+See [PRIVACY.md](PRIVACY.md) for full details.
+
+## 🐛 Troubleshooting
+
+### Import button not appearing? Stuck on the login request?
+- Ensure you're on the "Add a playlist" page
+- Refresh the page (the extension loads after page is ready)
+- Check that the extension is enabled in Chrome
+- Ensure third-party cookies are enabled for [*.]yotoplay.com 
+
+### Upload failing?
+- Verify file formats are supported
+- Check individual files are under 100MB
+- For podcasts, grant permission when prompted
+- Try refreshing and re-authenticating
+
+### Icons not matching well?
+- Use simple, clear track titles
+- Try the category-based matching for themed content
+
+### Extension lost connection?
+- This can happen with long uploads
+- The extension automatically recovers
+- Your upload will continue in the background
+
+## 👩‍💻 For Developers
+
+### Technical Stack
+
+- **Architecture**: Chrome Extension Manifest V3
+- **Content Scripts**: Inject functionality into Yoto pages
+- **Service Worker**: Handle API calls and authentication
+- **APIs**: Yoto Play API, Yoto Icons, ListenNotes Podcasts
+- **Libraries**: JSZip for file handling
+
+### Building from Source
+
+```bash
+# Clone the repository
+git clone https://github.com/carissaallen/yoto-myo-magic.git
+
+# Install dependencies (if any)
+npm install
+
+# Build for production
+./build.sh
+
+# The extension is ready to load in Chrome
 ```
-my-playlist/
-├── cover.jpg          # Album artwork (optional)
-├── 01 - Track One.mp3
-├── 02 - Track Two.mp3
-├── 03 - Track Three.mp3
-├── 1.png             # Icon for track 1 (optional)
-├── 2.png             # Icon for track 2 (optional)
-└── 3.png             # Icon for track 3 (optional)
-```
 
-## 📈 Privacy & Analytics
+### API Endpoints
 
-See [PRIVACY](PRIVACY.md) file for details
-
-- **Google Analytics 4**: Used to track feature usage (no personal data)
-- **Local Storage Only**: All settings stored locally in your browser
-- **No Server Storage**: We don't store any of your content or data
+The extension integrates with:
+- Yoto Play API (`api.yotoplay.com`)
+- Yoto Icons (`www.yotoicons.com`)
+- ListenNotes API (podcast search and metadata)
+- Google Analytics 4 (usage tracking)
 
 ## 🆘 Support
 
-### Getting Help
-- **Issues**: [Report bugs or request features](https://chromewebstore.google.com/detail/iehnjhgdgfepcjlbfkpngibijmffcmpp/support)
-
-### Common Issues
-
-**Import button not appearing?**
-- Make sure you're on the "Add a playlist" page
-- Try refreshing the page
-- Check that the extension is enabled
-
-**Upload failing?**
-- Check file formats (MP3, M4A, WAV, etc.)
-- Ensure files are under 100MB each
-
-**Icons not matching?**
-- Make sure track titles are descriptive
-- Use the manual search feature
+- **Bug Reports**: [Submit an issue](https://chromewebstore.google.com/detail/iehnjhgdgfepcjlbfkpngibijmffcmpp/support)
+- **Feature Requests**: Use the support link above
+- **Questions**: Check the troubleshooting section first
 
 ## 📝 License
 
@@ -117,9 +192,10 @@ MIT License - See [LICENSE](LICENSE) file for details
 
 ## 🙏 Acknowledgments
 
-- Thanks to the Yoto community for inspiration
-- Icon matching powered by Yoto's icon library
-- Built with love for busy parents and creative kids
+- The amazing Yoto community for inspiration and feedback
+- Yoto's delightful pixel art icon library
+- ListenNotes for podcast data
+- Every parent who's stayed up late making playlists
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ See [PRIVACY.md](PRIVACY.md) for full details.
 
 ### Import button not appearing? Stuck on the login request?
 - Ensure you're on the "Add a playlist" page
-- Refresh the page (the extension loads after page is ready)
+- Refresh the page (the extension loads after the page is ready)
 - Check that the extension is enabled in Chrome
 - Ensure third-party cookies are enabled for [*.]yotoplay.com 
 
@@ -195,7 +195,7 @@ MIT License - See [LICENSE](LICENSE) file for details
 - The amazing Yoto community for inspiration and feedback
 - Yoto's delightful pixel art icon library
 - ListenNotes for podcast data
-- Every parent who's stayed up late making playlists
+- Every parent who has stayed up late making playlists
 
 ---
 

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -844,22 +844,23 @@ async function searchIconsByCategory(category) {
 function getRelatedTerms(category) {
     const categoryMap = {
         'animals': ['animal', 'pet', 'zoo', 'farm', 'wildlife', 'dog', 'cat', 'bird'],
+        'art': ['paint', 'draw', 'color', 'brush', 'canvas', 'creative', 'craft'],
+        'buildings': ['house', 'home', 'office', 'city', 'architecture', 'building', 'tower'],
+        'chapters': ['number', 'book', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', 'chapter', 'introduction', 'credits', 'prologue', 'epilogue'],
+        'emotions': ['happy', 'sad', 'love', 'angry', 'smile', 'heart', 'feeling'],
+        'fantasy': ['magic', 'fairy', 'dragon', 'unicorn', 'wizard', 'castle', 'princess'],
+        'food': ['fruit', 'vegetable', 'meal', 'snack', 'drink', 'cooking', 'kitchen'],
+        'games': ['play', 'toy', 'puzzle', 'board', 'video', 'fun', 'entertainment'],
+        'holiday': ['christmas', 'easter', 'halloween', 'birthday', 'celebration', 'party'],
         'music': ['musical', 'instrument', 'song', 'note', 'piano', 'guitar', 'drum'],
         'nature': ['tree', 'flower', 'plant', 'forest', 'mountain', 'sun', 'cloud'],
-        'food': ['fruit', 'vegetable', 'meal', 'snack', 'drink', 'cooking', 'kitchen'],
-        'sports': ['sport', 'ball', 'game', 'team', 'football', 'basketball', 'soccer'],
-        'space': ['star', 'planet', 'moon', 'rocket', 'astronaut', 'galaxy', 'universe'],
         'school': ['education', 'learning', 'book', 'pencil', 'classroom', 'teacher', 'student'],
-        'transportation': ['car', 'train', 'plane', 'boat', 'bike', 'bus', 'vehicle'],
-        'weather': ['rain', 'snow', 'sun', 'cloud', 'storm', 'wind', 'temperature'],
-        'holiday': ['christmas', 'easter', 'halloween', 'birthday', 'celebration', 'party'],
-        'fantasy': ['magic', 'fairy', 'dragon', 'unicorn', 'wizard', 'castle', 'princess'],
         'science': ['experiment', 'chemistry', 'physics', 'biology', 'lab', 'research'],
-        'art': ['paint', 'draw', 'color', 'brush', 'canvas', 'creative', 'craft'],
-        'games': ['play', 'toy', 'puzzle', 'board', 'video', 'fun', 'entertainment'],
+        'space': ['star', 'planet', 'moon', 'rocket', 'astronaut', 'galaxy', 'universe'],
+        'sports': ['sport', 'ball', 'game', 'team', 'football', 'basketball', 'soccer'],
         'tools': ['hammer', 'wrench', 'screwdriver', 'build', 'fix', 'repair', 'construction'],
-        'buildings': ['house', 'home', 'office', 'city', 'architecture', 'building', 'tower'],
-        'emotions': ['happy', 'sad', 'love', 'angry', 'smile', 'heart', 'feeling']
+        'transportation': ['car', 'train', 'plane', 'boat', 'bike', 'bus', 'vehicle'],
+        'weather': ['rain', 'snow', 'sun', 'cloud', 'storm', 'wind', 'temperature']
     };
     
     const lowerCategory = category.toLowerCase();

--- a/content/content-simple.js
+++ b/content/content-simple.js
@@ -1637,7 +1637,7 @@ function showCategorySelectionModal(cardId, trackCount) {
   const categories = [
     'Animals', 'Music', 'Nature', 'Food', 'Sports', 'Space',
     'School', 'Transportation', 'Weather', 'Holiday', 'Fantasy',
-    'Science', 'Art', 'Games', 'Tools', 'Buildings', 'Emotions'
+    'Science', 'Art', 'Games', 'Tools', 'Buildings', 'Emotions', 'Chapters'
   ];
   
   content.innerHTML = `

--- a/content/content-simple.js
+++ b/content/content-simple.js
@@ -526,6 +526,13 @@ function createImportButton() {
 }
 
 function createButton() {
+  const buttonContainer = document.createElement('div');
+  buttonContainer.style.cssText = `
+    position: relative;
+    display: inline-flex;
+    margin-left: 8px;
+  `;
+  
   const button = document.createElement('button');
   button.id = 'yoto-magic-btn';
   
@@ -536,12 +543,18 @@ function createButton() {
     </svg>
   `;
   
+  const dropdownIcon = `
+    <svg width="12" height="12" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+  `;
+  
   button.style.cssText = `
     background-color: #ffffff;
     color: #3b82f6;
     border: 1px solid #3b82f6;
     padding: 8px 16px;
-    border-radius: 6px;
+    border-radius: 6px 0 0 6px;
     font-size: 13px;
     font-weight: 500;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
@@ -551,11 +564,85 @@ function createButton() {
     justify-content: center;
     gap: 8px;
     transition: all 0.2s ease;
-    margin-left: 8px;
     white-space: nowrap;
     line-height: 1.5;
     height: 40px;
+    border-right: none;
   `;
+  
+  const dropdownButton = document.createElement('button');
+  dropdownButton.style.cssText = `
+    background-color: #ffffff;
+    color: #3b82f6;
+    border: 1px solid #3b82f6;
+    padding: 8px;
+    border-radius: 0 6px 6px 0;
+    font-size: 13px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
+    height: 40px;
+    border-left: 1px solid #e5e7eb;
+  `;
+  
+  dropdownButton.innerHTML = dropdownIcon;
+  
+  const dropdownMenu = document.createElement('div');
+  dropdownMenu.style.cssText = `
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 4px;
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    display: none;
+    z-index: 1000;
+    min-width: 180px;
+  `;
+  
+  const generalOption = document.createElement('button');
+  generalOption.style.cssText = `
+    display: block;
+    width: 100%;
+    padding: 10px 16px;
+    text-align: left;
+    background: none;
+    border: none;
+    font-size: 13px;
+    color: #374151;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  `;
+  generalOption.textContent = 'Track Title';
+  generalOption.onmouseenter = () => generalOption.style.backgroundColor = '#f3f4f6';
+  generalOption.onmouseleave = () => generalOption.style.backgroundColor = 'transparent';
+  
+  const categoryOption = document.createElement('button');
+  categoryOption.style.cssText = `
+    display: block;
+    width: 100%;
+    padding: 10px 16px;
+    text-align: left;
+    background: none;
+    border: none;
+    font-size: 13px;
+    color: #374151;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    border-top: 1px solid #e5e7eb;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  `;
+  categoryOption.textContent = 'Category';
+  categoryOption.onmouseenter = () => categoryOption.style.backgroundColor = '#f3f4f6';
+  categoryOption.onmouseleave = () => categoryOption.style.backgroundColor = 'transparent';
+  
+  dropdownMenu.appendChild(generalOption);
+  dropdownMenu.appendChild(categoryOption);
   
   button.innerHTML = `
     ${puzzlePieceIcon}
@@ -576,7 +663,52 @@ function createButton() {
     button.style.transform = 'translateY(0)';
   };
   
+  dropdownButton.onmouseenter = () => {
+    dropdownButton.style.backgroundColor = '#f3f4f6';
+  };
+  
+  dropdownButton.onmouseleave = () => {
+    dropdownButton.style.backgroundColor = '#ffffff';
+  };
+  
+  dropdownButton.onclick = (e) => {
+    e.stopPropagation();
+    const isVisible = dropdownMenu.style.display === 'block';
+    dropdownMenu.style.display = isVisible ? 'none' : 'block';
+  };
+  
+  document.addEventListener('click', (e) => {
+    if (!buttonContainer.contains(e.target)) {
+      dropdownMenu.style.display = 'none';
+    }
+  });
+  
+  generalOption.onclick = async () => {
+    dropdownMenu.style.display = 'none';
+    await handleIconMatch('general');
+  };
+  
+  categoryOption.onclick = async () => {
+    dropdownMenu.style.display = 'none';
+    await handleIconMatch('category');
+  };
+  
   button.onclick = async () => {
+    await handleIconMatch('general');
+  };
+  
+  buttonContainer.appendChild(button);
+  buttonContainer.appendChild(dropdownButton);
+  buttonContainer.appendChild(dropdownMenu);
+  
+  return buttonContainer;
+}
+
+async function handleIconMatch(matchType) {
+  const button = document.getElementById('yoto-magic-btn');
+  const puzzlePieceIcon = button.querySelector('svg').outerHTML;
+  
+  if (matchType === 'general') {
     // Check cached auth status first
     const now = Date.now();
     if (!authCached || now - authCacheTime > AUTH_CACHE_DURATION) {
@@ -834,9 +966,10 @@ function createButton() {
       `;
       button.style.opacity = '1';
     }
-  };
-  
-  return button;
+  } else if (matchType === 'category') {
+    // Handle category match
+    await handleCategoryIconMatch();
+  }
 }
 
 function checkAndInjectButton() {
@@ -1430,6 +1563,430 @@ function showRefreshIndicator() {
   }
   
   document.body.appendChild(indicator);
+}
+
+async function handleCategoryIconMatch() {
+  const authResponse = await chrome.runtime.sendMessage({ action: 'CHECK_AUTH' });
+  if (!authResponse.authenticated) {
+    chrome.runtime.sendMessage({ action: 'START_AUTH' });
+    return;
+  }
+  
+  const urlMatch = window.location.href.match(/\/card\/([^\/]+)/);
+  const cardId = urlMatch ? urlMatch[1] : null;
+  
+  if (!cardId) {
+    alert('Could not identify card ID from URL');
+    return;
+  }
+  
+  const contentResponse = await chrome.runtime.sendMessage({
+    action: 'GET_CARD_CONTENT',
+    cardId: cardId
+  });
+  
+  let trackCount = 0;
+  if (contentResponse.card && contentResponse.card.content && contentResponse.card.content.chapters) {
+    // Count the number of chapters (each chapter is typically one track in MYO cards)
+    trackCount = contentResponse.card.content.chapters.length;
+  }
+  
+  if (trackCount === 0) {
+    // Try to get tracks from DOM as fallback
+    const trackElements = document.querySelectorAll('[data-testid^="track-"]');
+    trackCount = trackElements.length;
+  }
+  
+  if (trackCount === 0) {
+    alert('No tracks found in this card. Please add some tracks first.');
+    return;
+  }
+  
+  showCategorySelectionModal(cardId, trackCount);
+}
+
+function showCategorySelectionModal(cardId, trackCount) {
+  const modal = document.createElement('div');
+  modal.style.cssText = `
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 99999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  `;
+  
+  const content = document.createElement('div');
+  content.style.cssText = `
+    background: white;
+    border-radius: 12px;
+    padding: 30px;
+    max-width: 500px;
+    width: 90%;
+    max-height: 80vh;
+    overflow-y: auto;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  `;
+  
+  // Common categories for icons
+  const categories = [
+    'Animals', 'Music', 'Nature', 'Food', 'Sports', 'Space',
+    'School', 'Transportation', 'Weather', 'Holiday', 'Fantasy',
+    'Science', 'Art', 'Games', 'Tools', 'Buildings', 'Emotions'
+  ];
+  
+  content.innerHTML = `
+    <h2 style="margin: 0 0 20px 0; color: #2c3e50; font-size: 24px;">Category Icon Match</h2>
+    <p style="margin: 0 0 20px 0; color: #666; font-size: 14px;">
+      Select a category to find icons for your ${trackCount} track${trackCount !== 1 ? 's' : ''}
+    </p>
+    
+    <div style="margin-bottom: 20px;">
+      <label style="display: block; margin-bottom: 8px; font-weight: 500; color: #374151;">
+        Choose a category:
+      </label>
+      <select id="category-select" style="
+        width: 100%;
+        padding: 10px;
+        border: 1px solid #d1d5db;
+        border-radius: 6px;
+        font-size: 14px;
+      ">
+        <option value="">Select a category...</option>
+        ${categories.map(cat => `<option value="${cat.toLowerCase()}">${cat}</option>`).join('')}
+      </select>
+    </div>
+    
+    <div style="margin-bottom: 20px;">
+      <label style="display: block; margin-bottom: 8px; font-weight: 500; color: #374151;">
+        Or enter a custom category:
+      </label>
+      <input type="text" id="custom-category" placeholder="e.g., dinosaurs, robots, fairy tales" style="
+        width: 100%;
+        padding: 10px;
+        border: 1px solid #d1d5db;
+        border-radius: 6px;
+        font-size: 14px;
+      ">
+    </div>
+    
+    <div style="display: flex; gap: 12px; justify-content: flex-end;">
+      <button id="category-cancel" style="
+        padding: 10px 20px;
+        background: #f3f4f6;
+        border: none;
+        border-radius: 6px;
+        cursor: pointer;
+        font-size: 14px;
+        font-weight: 500;
+      ">Cancel</button>
+      <button id="category-search" style="
+        padding: 10px 20px;
+        background: #3b82f6;
+        color: white;
+        border: none;
+        border-radius: 6px;
+        cursor: pointer;
+        font-size: 14px;
+        font-weight: 500;
+      ">Search Icons</button>
+    </div>
+  `;
+  
+  modal.appendChild(content);
+  document.body.appendChild(modal);
+  
+  const categorySelect = document.getElementById('category-select');
+  const customCategory = document.getElementById('custom-category');
+  
+  categorySelect.addEventListener('change', () => {
+    if (categorySelect.value) {
+      customCategory.value = '';
+    }
+  });
+  
+  customCategory.addEventListener('input', () => {
+    if (customCategory.value) {
+      categorySelect.value = '';
+    }
+  });
+  
+  document.getElementById('category-cancel').addEventListener('click', () => {
+    modal.remove();
+  });
+  
+  document.getElementById('category-search').addEventListener('click', async () => {
+    const category = customCategory.value || categorySelect.value;
+    
+    if (!category) {
+      alert('Please select or enter a category');
+      return;
+    }
+    
+    const searchBtn = document.getElementById('category-search');
+    searchBtn.textContent = 'Searching...';
+    searchBtn.disabled = true;
+    
+    const searchResponse = await chrome.runtime.sendMessage({
+      action: 'SEARCH_ICONS_BY_CATEGORY',
+      category: category
+    });
+    
+    if (searchResponse.error) {
+      alert('Error searching for icons: ' + searchResponse.error);
+      modal.remove();
+      return;
+    }
+    
+    if (!searchResponse.icons || searchResponse.icons.length === 0) {
+      alert(`No icons found for category "${category}". Please try another category.`);
+      searchBtn.textContent = 'Search Icons';
+      searchBtn.disabled = false;
+      return;
+    }
+    
+    modal.remove();
+    showIconSelectionModal(cardId, trackCount, searchResponse.icons, category);
+  });
+}
+
+function showIconSelectionModal(cardId, trackCount, icons, category) {
+  const modal = document.createElement('div');
+  modal.style.cssText = `
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 99999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  `;
+  
+  const content = document.createElement('div');
+  content.style.cssText = `
+    background: white;
+    border-radius: 12px;
+    padding: 30px;
+    max-width: 800px;
+    width: 90%;
+    max-height: 80vh;
+    overflow-y: auto;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  `;
+  
+  content.innerHTML = `
+    <h2 style="margin: 0 0 10px 0; color: #2c3e50; font-size: 24px;">Select Icons for "${category}"</h2>
+    <p style="margin: 0 0 20px 0; color: #666; font-size: 14px;">
+      Choose icons to apply to your ${trackCount} tracks. Selected icons will be applied in order and repeated if needed.
+    </p>
+    
+    <div id="icon-grid" style="
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+      gap: 12px;
+      margin-bottom: 20px;
+      max-height: 400px;
+      overflow-y: auto;
+      padding: 10px;
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+    "></div>
+    
+    <div style="margin-bottom: 20px; padding: 10px; background: #f9fafb; border-radius: 6px;">
+      <p style="margin: 0; font-size: 13px; color: #6b7280;">
+        <strong>Selected:</strong> <span id="selected-count">0</span> icon(s)
+      </p>
+      <p style="margin: 4px 0 0 0; font-size: 12px; color: #9ca3af;">
+        Icons will be applied to tracks in the order selected
+      </p>
+    </div>
+    
+    <div style="display: flex; gap: 12px; justify-content: flex-end;">
+      <button id="icon-cancel" style="
+        padding: 10px 20px;
+        background: #f3f4f6;
+        border: none;
+        border-radius: 6px;
+        cursor: pointer;
+        font-size: 14px;
+        font-weight: 500;
+      ">Cancel</button>
+      <button id="icon-apply" style="
+        padding: 10px 20px;
+        background: #3b82f6;
+        color: white;
+        border: none;
+        border-radius: 6px;
+        cursor: pointer;
+        font-size: 14px;
+        font-weight: 500;
+      " disabled>Apply Icons</button>
+    </div>
+  `;
+  
+  modal.appendChild(content);
+  document.body.appendChild(modal);
+  
+  const iconGrid = document.getElementById('icon-grid');
+  const selectedIcons = [];
+  const selectedIconElements = new Map();
+  
+  icons.forEach((icon, index) => {
+    const iconDiv = document.createElement('div');
+    iconDiv.style.cssText = `
+      position: relative;
+      cursor: pointer;
+      border: 2px solid transparent;
+      border-radius: 8px;
+      padding: 8px;
+      transition: all 0.2s;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      background: white;
+    `;
+    
+    const img = document.createElement('img');
+    img.src = icon.url || icon.mediaUrl || `https://api.yotoplay.com/media/${icon.mediaId}`;
+    img.style.cssText = `
+      width: 60px;
+      height: 60px;
+      object-fit: cover;
+      border-radius: 4px;
+    `;
+    
+    const orderBadge = document.createElement('div');
+    orderBadge.style.cssText = `
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      background: #3b82f6;
+      color: white;
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+      font-weight: bold;
+    `;
+    
+    iconDiv.appendChild(img);
+    iconDiv.appendChild(orderBadge);
+    
+    iconDiv.addEventListener('click', () => {
+      const iconIndex = selectedIcons.findIndex(i => i.mediaId === icon.mediaId);
+      
+      if (iconIndex >= 0) {
+        selectedIcons.splice(iconIndex, 1);
+        iconDiv.style.borderColor = 'transparent';
+        iconDiv.style.backgroundColor = 'white';
+        orderBadge.style.display = 'none';
+        selectedIconElements.delete(icon.mediaId);
+        
+        updateOrderBadges();
+      } else {
+        selectedIcons.push(icon);
+        iconDiv.style.borderColor = '#3b82f6';
+        iconDiv.style.backgroundColor = '#eff6ff';
+        orderBadge.style.display = 'flex';
+        orderBadge.textContent = selectedIcons.length;
+        selectedIconElements.set(icon.mediaId, orderBadge);
+      }
+      
+      document.getElementById('selected-count').textContent = selectedIcons.length;
+      document.getElementById('icon-apply').disabled = selectedIcons.length === 0;
+    });
+    
+    iconGrid.appendChild(iconDiv);
+  });
+  
+  function updateOrderBadges() {
+    selectedIcons.forEach((icon, index) => {
+      const badge = selectedIconElements.get(icon.mediaId);
+      if (badge) {
+        badge.textContent = index + 1;
+      }
+    });
+  }
+  
+  document.getElementById('icon-cancel').addEventListener('click', () => {
+    modal.remove();
+  });
+  
+  document.getElementById('icon-apply').addEventListener('click', async () => {
+    if (selectedIcons.length === 0) return;
+    
+    const applyBtn = document.getElementById('icon-apply');
+    applyBtn.textContent = 'Applying...';
+    applyBtn.disabled = true;
+    
+    const result = await chrome.runtime.sendMessage({
+      action: 'APPLY_CATEGORY_ICONS',
+      cardId: cardId,
+      icons: selectedIcons
+    });
+    
+    if (result.error) {
+      alert('Error applying icons: ' + result.error);
+    } else {
+      // Calculate the actual number of unique icons applied (capped at track count)
+      const iconsApplied = Math.min(selectedIcons.length, trackCount);
+      
+      modal.innerHTML = `
+        <div style="
+          background: white;
+          border-radius: 12px;
+          padding: 40px;
+          text-align: center;
+          max-width: 400px;
+        ">
+          <div style="
+            width: 60px;
+            height: 60px;
+            background: #10b981;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0 auto 20px;
+          ">
+            <svg width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3">
+              <path d="M20 6L9 17l-5-5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </div>
+          <h3 style="margin: 0 0 10px 0; color: #2c3e50;">Success!</h3>
+          <p style="margin: 0 0 20px 0; color: #666;">
+            Applied ${iconsApplied} icon${iconsApplied !== 1 ? 's' : ''} to ${trackCount} track${trackCount !== 1 ? 's' : ''}
+          </p>
+          <button onclick="window.location.reload()" style="
+            padding: 10px 20px;
+            background: #3b82f6;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 14px;
+            font-weight: 500;
+          ">Reload Page</button>
+        </div>
+      `;
+      
+      setTimeout(() => {
+        window.location.reload();
+      }, 3000);
+    }
+  });
 }
 
 })(); // End of IIFE

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -181,4 +181,7 @@ if (typeof module !== 'undefined' && module.exports) {
     module.exports = analytics;
 } else if (typeof window !== 'undefined') {
     window.YotoAnalytics = analytics;
+} else {
+    // For service worker context (no window object)
+    self.YotoAnalytics = analytics;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Yoto MYO Magic",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Transform how you create Yoto MYO cards with smart imports, automatic icon matching, and more delightful shortcuts.",
 
   "permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -55,6 +55,13 @@
       ],
       "js": ["jszip.min.js", "content/content.js"],
       "run_at": "document_idle"
+    },
+    {
+      "matches": [
+        "https://my.yotoplay.com/card/*/edit"
+      ],
+      "js": ["content/content-simple.js"],
+      "run_at": "document_idle"
     }
   ],
   


### PR DESCRIPTION
This pull request introduces the new "Category Icon Matching" feature, improves category-based icon search and application, updates analytics compatibility for service workers, and refreshes documentation for the v1.3.0 release. It also updates the extension manifest for the new version and adds support for additional content scripts.

**New Category Icon Matching Feature:**

* Added `searchIconsByCategory` and `applyCategoryIcons` functions to enable searching for and applying themed icons to multiple tracks at once, including a related-terms map for better icon results and logic to assign icons in a repeating pattern across playlist chapters.
* Extended the service worker message handler to support new actions: `SEARCH_ICONS_BY_CATEGORY` and `APPLY_CATEGORY_ICONS`.

**Analytics Compatibility:**

* Updated `lib/analytics.js` to expose `YotoAnalytics` on the `self` object for compatibility with service worker environments, ensuring analytics work outside the window context.

**Documentation and Versioning:**

* Overhauled `README.md` to reflect new features (category icon matching, podcast import), improved instructions, and added developer notes.
* Updated `manifest.json` to version 1.3.0 and added a new content script for the card edit page. [[1]](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L4-R4) [[2]](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743R58-R64)