### PR TITLE
Add icons-only update support to Update Playlist feature

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -1606,55 +1606,84 @@ async function updatePlaylistContent(cardId, existingChapters, newTracks, newIco
 
         let chapters = [...(existingChapters || [])];
 
-        let maxChapterNum = 0;
-        chapters.forEach(chapter => {
-            const num = parseInt(chapter.key);
-            if (!isNaN(num) && num > maxChapterNum) {
-                maxChapterNum = num;
-            }
-        });
+        if (newTracks && newTracks.length > 0) {
+            let maxChapterNum = 0;
+            chapters.forEach(chapter => {
+                const num = parseInt(chapter.key);
+                if (!isNaN(num) && num > maxChapterNum) {
+                    maxChapterNum = num;
+                }
+            });
 
-        newTracks.forEach((track, index) => {
-            const chapterNum = maxChapterNum + index + 1;
-            const chapterKey = String(chapterNum).padStart(2, '0');
+            newTracks.forEach((track, index) => {
+                const chapterNum = maxChapterNum + index + 1;
+                const chapterKey = String(chapterNum).padStart(2, '0');
 
-            let iconId = 'yoto:#aUm9i3ex3qqAMYBv-i-O-pYMKuMJGICtR3Vhf289u2Q';
-            if (newIcons && newIcons[index]) {
-                iconId = newIcons[index].startsWith('yoto:#') ? newIcons[index] : `yoto:#${newIcons[index]}`;
-            }
+                let iconId = 'yoto:#aUm9i3ex3qqAMYBv-i-O-pYMKuMJGICtR3Vhf289u2Q';
+                if (newIcons && newIcons[index]) {
+                    iconId = newIcons[index].startsWith('yoto:#') ? newIcons[index] : `yoto:#${newIcons[index]}`;
+                }
 
-            let format = track.format || 'mp3';
-            const validFormats = ['mp3', 'aac', 'alac', 'flac', 'pcm_s16le', 'opus', 'ogg', 'x-m4a', 'wav', 'aiff', 'mpeg'];
-            if (!validFormats.includes(format)) {
-                format = 'mp3';
-            }
+                let format = track.format || 'mp3';
+                const validFormats = ['mp3', 'aac', 'alac', 'flac', 'pcm_s16le', 'opus', 'ogg', 'x-m4a', 'wav', 'aiff', 'mpeg'];
+                if (!validFormats.includes(format)) {
+                    format = 'mp3';
+                }
 
-            const chapter = {
-                key: chapterKey,
-                title: track.title || `Track ${chapterNum}`,
-                overlayLabel: String(chapterNum),
-                display: {
-                    icon16x16: iconId,
-                    overlayLabel: {
-                        label: String(chapterNum)
-                    }
-                },
-                tracks: [{
-                    format: format,
-                    key: track.key,
-                    trackId: generateRandomId(),
+                const chapter = {
+                    key: chapterKey,
                     title: track.title || `Track ${chapterNum}`,
-                    trackUrl: track.trackUrl || `yoto:#${track.key}`,
-                    type: 'audio',
+                    overlayLabel: String(chapterNum),
                     display: {
-                        icon16x16: iconId
+                        icon16x16: iconId,
+                        overlayLabel: {
+                            label: String(chapterNum)
+                        }
                     },
-                    duration: track.duration || 0
-                }]
-            };
+                    tracks: [{
+                        format: format,
+                        key: track.key,
+                        trackId: generateRandomId(),
+                        title: track.title || `Track ${chapterNum}`,
+                        trackUrl: track.trackUrl || `yoto:#${track.key}`,
+                        type: 'audio',
+                        display: {
+                            icon16x16: iconId
+                        },
+                        duration: track.duration || 0
+                    }]
+                };
 
-            chapters.push(chapter);
-        });
+                chapters.push(chapter);
+            });
+        }
+        // If we only have icons (no new tracks), update existing chapters with new icons
+        else if (newIcons && newIcons.length > 0) {
+            chapters.forEach((chapter, chapterIndex) => {
+                if (newIcons[chapterIndex]) {
+                    const iconId = newIcons[chapterIndex].startsWith('yoto:#')
+                        ? newIcons[chapterIndex]
+                        : `yoto:#${newIcons[chapterIndex]}`;
+
+                    if (chapter.display) {
+                        chapter.display.icon16x16 = iconId;
+                    } else {
+                        chapter.display = { icon16x16: iconId };
+                    }
+
+                    // Update all tracks within this chapter with the same icon
+                    if (chapter.tracks && Array.isArray(chapter.tracks)) {
+                        chapter.tracks.forEach(track => {
+                            if (track.display) {
+                                track.display.icon16x16 = iconId;
+                            } else {
+                                track.display = { icon16x16: iconId };
+                            }
+                        });
+                    }
+                }
+            });
+        }
 
         const updateBody = {
             createdByClientId: cardContent.card.createdByClientId,
@@ -1682,10 +1711,14 @@ async function updatePlaylistContent(cardId, existingChapters, newTracks, newIco
             return { error: updateResponse.error };
         }
 
+        const addedTracks = (newTracks && newTracks.length > 0) ? newTracks.length : 0;
+        const updatedIcons = (newIcons && newTracks && newTracks.length === 0) ? newIcons.filter(icon => icon).length : 0;
+
         return {
             success: true,
             cardId: cardId,
-            addedTracks: newTracks.length,
+            addedTracks: addedTracks,
+            updatedIcons: updatedIcons,
             totalChapters: chapters.length
         };
 
@@ -2802,7 +2835,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                     });
                     sendResponse(iconResponse);
                     break;
-                    
+
                 case 'UPLOAD_COVER':
                     // Upload cover image and get its public URL
                     const coverResponse = await uploadCoverImage({

--- a/content/content.js
+++ b/content/content.js
@@ -5577,13 +5577,21 @@ async function showUpdateProgressModal(audioFiles, iconFiles, cardId) {
     </h2>
 
     <div style="margin-bottom: 20px; color: #666;">
-      <p style="margin: 0 0 8px 0;">Ready to add to existing card:</p>
+      <p style="margin: 0 0 8px 0;">${audioFiles.length > 0 ? 'Ready to add to existing card:' : 'Ready to update existing card icons:'}</p>
       <ul style="margin: 8px 0; padding-left: 20px; font-size: 14px;">
         ${audioFiles.length > 0 ? `<li>${audioFiles.length} audio file${audioFiles.length !== 1 ? 's' : ''}</li>` : ''}
         ${iconFiles.length > 0 ? `<li>${iconFiles.length} icon file${iconFiles.length !== 1 ? 's' : ''}</li>` : ''}
       </ul>
       <p style="color: #10b981; font-size: 13px; margin: 8px 0;">✓ Existing content will be preserved</p>
       <p style="color: #10b981; font-size: 13px; margin: 8px 0;">✓ Cover image will not be changed</p>
+      ${audioFiles.length === 0 && iconFiles.length > 0 ? `<p style="color: #3b82f6; font-size: 13px; margin: 8px 0; display: flex; align-items: center; gap: 6px;">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style="flex-shrink: 0;">
+          <circle cx="12" cy="12" r="10" stroke="#3b82f6" stroke-width="2"/>
+          <path d="M12 16V12" stroke="#3b82f6" stroke-width="2" stroke-linecap="round"/>
+          <circle cx="12" cy="8" r="1" fill="#3b82f6"/>
+        </svg>
+        <span>Icons will be applied to tracks based on filename numbers</span>
+      </p>` : ''}
     </div>
 
     <div style="margin: 20px 0;">
@@ -5651,12 +5659,15 @@ async function performCardUpdate(audioFiles, iconFiles, cardId, modal) {
     const existingMetadata = cardContent.card?.metadata || {};
     const existingTitle = cardContent.card?.title || state.updateCardTitle;
 
-    statusText.textContent = 'Uploading audio files...';
-    progressBar.style.width = '30%';
-    percentageText.textContent = '30%';
-
     const uploadedTracks = [];
-    const uploadStrategy = audioFiles.length >= 10 ? 'chunked' : 'parallel';
+
+    // Only upload audio files if we have any
+    if (audioFiles.length > 0) {
+      statusText.textContent = 'Uploading audio files...';
+      progressBar.style.width = '30%';
+      percentageText.textContent = '30%';
+
+      const uploadStrategy = audioFiles.length >= 10 ? 'chunked' : 'parallel';
 
     if (uploadStrategy === 'chunked') {
       const chunkSize = 8;
@@ -5754,6 +5765,7 @@ async function performCardUpdate(audioFiles, iconFiles, cardId, modal) {
         }
       });
     }
+    } // Close the if (audioFiles.length > 0) block
 
     // Filter out any undefined entries (failed uploads)
     const validTracks = uploadedTracks.filter(track => track !== undefined);
@@ -5761,8 +5773,10 @@ async function performCardUpdate(audioFiles, iconFiles, cardId, modal) {
     let uploadedIcons = [];
     if (iconFiles.length > 0) {
       statusText.textContent = 'Uploading icon files...';
-      progressBar.style.width = '75%';
-      percentageText.textContent = '75%';
+      // Adjust progress based on whether we had audio files
+      const iconProgressStart = audioFiles.length > 0 ? 75 : 30;
+      progressBar.style.width = `${iconProgressStart}%`;
+      percentageText.textContent = `${iconProgressStart}%`;
 
       for (let i = 0; i < iconFiles.length; i++) {
         const icon = iconFiles[i];
@@ -5813,7 +5827,17 @@ async function performCardUpdate(audioFiles, iconFiles, cardId, modal) {
     percentageText.textContent = '100%';
     progressBar.style.background = '#10b981';
 
-    showNotification(`Successfully updated "${existingTitle}" with ${validTracks.length} new tracks`, 'success');
+    // Create appropriate success message based on what was updated
+    let successMessage = `Successfully updated "${existingTitle}"`;
+    if (validTracks.length > 0 && uploadedIcons.length > 0) {
+      successMessage += ` with ${validTracks.length} new tracks and ${uploadedIcons.filter(icon => icon).length} icons`;
+    } else if (validTracks.length > 0) {
+      successMessage += ` with ${validTracks.length} new tracks`;
+    } else if (updateResult.updatedIcons > 0) {
+      successMessage += ` with ${updateResult.updatedIcons} new icons`;
+    }
+
+    showNotification(successMessage, 'success');
 
     setTimeout(() => {
       modal.remove();


### PR DESCRIPTION
This pull request enhances the update workflow for playlists and cards by adding support for updating icons independently of tracks, improving user feedback, and refining progress reporting. The changes ensure that icons can be updated even when no new audio tracks are provided, and that both the UI and backend logic accurately reflect these updates.

**Playlist and card update logic improvements:**

* Added logic to update chapter and track icons when only icon files are provided (no new tracks), ensuring icons are applied correctly across chapters and tracks.
* Modified the return value of `updatePlaylistContent` to include both the number of added tracks and updated icons, providing more granular feedback on what was changed.

**User interface and progress feedback enhancements:**

* Updated the progress modal to display context-sensitive messages, distinguishing between adding tracks and updating icons, and providing a clear explanation for icon-only updates.
* Adjusted progress bar behavior to reflect whether audio or icon files are being uploaded, improving accuracy of progress feedback.
* Improved notification messaging to clearly indicate whether tracks, icons, or both were updated, giving users precise information about the result of their action.

**Code organization:**

* Ensured that track uploads are only attempted when audio files are present, preventing unnecessary operations when updating icons only.